### PR TITLE
Allow nvidia-modprobe to early out in the event of blacklisting via modprobe '--use-blacklist' switch

### DIFF
--- a/modprobe-utils/nvidia-modprobe-utils.c
+++ b/modprobe-utils/nvidia-modprobe-utils.c
@@ -343,7 +343,7 @@ static int modprobe_helper(const int print_errors, const char *module_name,
              */
             silence_current_process();
 
-            execle(modprobe_path, "modprobe",
+            execle(modprobe_path, "modprobe", "--use-blacklist",
                    module_name, NULL, envp);
 
             /* If execl(3) returned, then an error has occurred. */


### PR DESCRIPTION
Allows `nvidia-modprobe` to early out when it calls `modprobe` by supplying the `--use-blacklist` switch.
This allows modprobe to early out in the event that the nvidia driver has been intentionally blacklisted.

See https://github.com/NVIDIA/nvidia-modprobe/issues/5